### PR TITLE
Fix of address already in use on udp.addMembership method

### DIFF
--- a/lib/dns-sd.js
+++ b/lib/dns-sd.js
@@ -420,7 +420,11 @@ DnsSd.prototype._stopDiscovery = function () {
 
 DnsSd.prototype._addMembership = function () {
 	this._source_address_list.forEach((netif) => {
-		this._udp.addMembership(this._MULTICAST_ADDR, netif);
+		try {
+			this._udp.addMembership(this._MULTICAST_ADDR, netif);
+		} catch(e) {
+			console.log(`Catching error on address already in use: ${JSON.stringify(e)}`);
+		}
 	});
 };
 


### PR DESCRIPTION
If an interface, due to dhcp release time, have more than a one IPv4 the addMembership method of udp fall into an error that cause an uncatchable error that restarts the node process.
I fixed the error just add a try/catch state on row 423 of dns-sd.js
I push the fix into another branch and do a pull request into master