### PR TITLE
catch dropMembership error

### DIFF
--- a/lib/dns-sd.js
+++ b/lib/dns-sd.js
@@ -430,7 +430,11 @@ DnsSd.prototype._addMembership = function () {
 
 DnsSd.prototype._dropMembership = function () {
 	this._source_address_list.forEach((netif) => {
-		this._udp.dropMembership(this._MULTICAST_ADDR, netif);
+		try {
+			this._udp.dropMembership(this._MULTICAST_ADDR, netif);
+		} catch(e) {
+			console.log(`Catching error on dropMembership EADDRNOTAVAIL: ${JSON.stringify(e)}`);
+		}
 	});
 };
 

--- a/lib/dns-sd.js
+++ b/lib/dns-sd.js
@@ -433,7 +433,7 @@ DnsSd.prototype._dropMembership = function () {
 		try {
 			this._udp.dropMembership(this._MULTICAST_ADDR, netif);
 		} catch(e) {
-			console.log(`Catching error on dropMembership EADDRNOTAVAIL: ${JSON.stringify(e)}`);
+			console.log(`Catching error on dropMembership: ${JSON.stringify(e)}`);
 		}
 	});
 };


### PR DESCRIPTION
I was experiencing these errors:
```
(node:8214) UnhandledPromiseRejectionWarning: Error: dropMembership EADDRNOTAVAIL
    at Socket.dropMembership (dgram.js:835:11)
    at /usr/local/lib/node_modules/homebridge-ewelink/node_modules/node-dns-sd/lib/dns-sd.js:433:13
    at Array.forEach (<anonymous>:null:null)
    at DnsSd._dropMembership (/usr/local/lib/node_modules/homebridge-ewelink/node_modules/node-dns-sd/lib/dns-sd.js:432:28)
    at /usr/local/lib/node_modules/homebridge-ewelink/node_modules/node-dns-sd/lib/dns-sd.js:527:8
    at new Promise (<anonymous>:null:null)
    at DnsSd._stopListening (/usr/local/lib/node_modules/homebridge-ewelink/node_modules/node-dns-sd/lib/dns-sd.js:526:16)
    at /usr/local/lib/node_modules/homebridge-ewelink/node_modules/node-dns-sd/lib/dns-sd.js:467:9
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

(node:8214) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:8214) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```